### PR TITLE
feat: parse kernel path field

### DIFF
--- a/file_metrics.go
+++ b/file_metrics.go
@@ -62,3 +62,13 @@ func (self *FileInformationXP) Filenames() []string {
 
 	return result
 }
+
+func (self *FileInformationWin10) ExecutablePath() string {
+	size := self.ExecutablePathSize()
+	// size seems to be always 4 bytes larger than the actual path.
+	if size < 4 {
+		return ""
+	}
+	size -= 4
+	return ParseUTF16String(self.Reader, int64(self.ExecutablePathOffset()), int64(size))
+}

--- a/model.go
+++ b/model.go
@@ -5,7 +5,10 @@ import (
 )
 
 type PrefetchInfo struct {
-	Executable    string      `json:"Executable"`
+	Executable string `json:"Executable"`
+	// Path contains a kernel path to the executable.
+	// For Windows Apps, it apparently contains the app name instead.
+	Path          string      `json:"Path"`
 	FileSize      uint32      `json:"FileSize"`
 	Hash          string      `json:"Hash"`
 	Version       string      `json:"Version"`

--- a/prefetch.go
+++ b/prefetch.go
@@ -92,6 +92,10 @@ func LoadPrefetch(reader io.ReaderAt) (*PrefetchInfo, error) {
 		if self.RunCount == 0 {
 			self.RunCount = file_info.RunCount2()
 		}
+		switch self.Version {
+		case "Win10", "Win11", "Unknown":
+			self.Path = file_info.ExecutablePath()
+		}
 	}
 
 	return self, nil

--- a/prefetch_gen.go
+++ b/prefetch_gen.go
@@ -8,8 +8,6 @@ import (
     "fmt"
     "bytes"
     "io"
-    "sort"
-    "strings"
     "unicode/utf16"
     "unicode/utf8"
 )
@@ -22,73 +20,62 @@ var (
    _ = utf16.Decode
    _ = binary.LittleEndian
    _ = utf8.RuneError
-   _ = sort.Strings
-   _ = strings.Join
-   _ = io.Copy
 )
-
-func indent(text string) string {
-    result := []string{}
-    lines := strings.Split(text,"\n")
-    for _, line := range lines {
-         result = append(result, "  " + line)
-    }
-    return strings.Join(result, "\n")
-}
-
 
 type PrefetchProfile struct {
     Off_FileInformationVista_FileMetricsOffset int64
-    Off_FileInformationVista_NumberOfFileMetrics int64
-    Off_FileInformationVista_TraceChainsArrayOffset int64
-    Off_FileInformationVista_NumberOfTraceChains int64
     Off_FileInformationVista_FilenameOffset int64
     Off_FileInformationVista_FilenameSize int64
-    Off_FileInformationVista_VolumesInformationOffset int64
-    Off_FileInformationVista_NumberOfVolumes int64
-    Off_FileInformationVista_VolumesInformationSize int64
     Off_FileInformationVista_LastRunTime int64
+    Off_FileInformationVista_NumberOfFileMetrics int64
+    Off_FileInformationVista_NumberOfTraceChains int64
+    Off_FileInformationVista_NumberOfVolumes int64
     Off_FileInformationVista_RunCount int64
+    Off_FileInformationVista_TraceChainsArrayOffset int64
+    Off_FileInformationVista_VolumesInformationOffset int64
+    Off_FileInformationVista_VolumesInformationSize int64
+    Off_FileInformationWin10_ExecutablePathOffset int64
+    Off_FileInformationWin10_ExecutablePathSize int64
     Off_FileInformationWin10_FileMetricsOffset int64
-    Off_FileInformationWin10_NumberOfFileMetrics int64
-    Off_FileInformationWin10_TraceChainsArrayOffset int64
-    Off_FileInformationWin10_NumberOfTraceChains int64
     Off_FileInformationWin10_FilenameOffset int64
     Off_FileInformationWin10_FilenameSize int64
-    Off_FileInformationWin10_VolumesInformationOffset int64
-    Off_FileInformationWin10_NumberOfVolumes int64
-    Off_FileInformationWin10_VolumesInformationSize int64
     Off_FileInformationWin10_LastRunTimes int64
+    Off_FileInformationWin10_NumberOfFileMetrics int64
+    Off_FileInformationWin10_NumberOfTraceChains int64
+    Off_FileInformationWin10_NumberOfVolumes int64
     Off_FileInformationWin10_RunCount1 int64
     Off_FileInformationWin10_RunCount2 int64
+    Off_FileInformationWin10_TraceChainsArrayOffset int64
+    Off_FileInformationWin10_VolumesInformationOffset int64
+    Off_FileInformationWin10_VolumesInformationSize int64
     Off_FileInformationXP_FileMetricsOffset int64
-    Off_FileInformationXP_NumberOfFileMetrics int64
-    Off_FileInformationXP_TraceChainsArrayOffset int64
-    Off_FileInformationXP_NumberOfTraceChains int64
     Off_FileInformationXP_FilenameOffset int64
     Off_FileInformationXP_FilenameSize int64
-    Off_FileInformationXP_VolumesInformationOffset int64
-    Off_FileInformationXP_NumberOfVolumes int64
-    Off_FileInformationXP_VolumesInformationSize int64
     Off_FileInformationXP_LastRunTime int64
+    Off_FileInformationXP_NumberOfFileMetrics int64
+    Off_FileInformationXP_NumberOfTraceChains int64
+    Off_FileInformationXP_NumberOfVolumes int64
     Off_FileInformationXP_RunCount int64
-    Off_FileMetricsEntryV17_FilenameOffset int64
+    Off_FileInformationXP_TraceChainsArrayOffset int64
+    Off_FileInformationXP_VolumesInformationOffset int64
+    Off_FileInformationXP_VolumesInformationSize int64
     Off_FileMetricsEntryV17_FilenameLength int64
-    Off_FileMetricsEntryV30_FilenameOffset int64
+    Off_FileMetricsEntryV17_FilenameOffset int64
     Off_FileMetricsEntryV30_FilenameLength int64
+    Off_FileMetricsEntryV30_FilenameOffset int64
     Off_FileMetricsEntryV30_MFTFileReference int64
     Off_MAMHeader_Signature int64
     Off_MAMHeader_UncompressedSize int64
-    Off_SCCAHeader_Version int64
-    Off_SCCAHeader_Signature int64
-    Off_SCCAHeader_FileSize int64
     Off_SCCAHeader_Executable int64
+    Off_SCCAHeader_FileSize int64
     Off_SCCAHeader_Hash int64
+    Off_SCCAHeader_Signature int64
+    Off_SCCAHeader_Version int64
 }
 
 func NewPrefetchProfile() *PrefetchProfile {
     // Specific offsets can be tweaked to cater for slight version mismatches.
-    self := &PrefetchProfile{0,4,8,12,16,20,24,28,32,44,68,0,4,8,12,16,20,24,28,32,44,124,116,0,4,8,12,16,20,24,28,32,36,60,8,12,12,16,24,0,4,0,4,12,16,76}
+    self := &PrefetchProfile{0,16,20,44,4,12,28,68,8,24,32,128,132,0,16,20,44,4,12,28,124,116,8,24,32,0,16,20,36,4,12,28,60,8,24,32,12,8,16,12,24,0,4,16,12,76,4,0}
     return self
 }
 
@@ -127,24 +114,17 @@ type FileInformationVista struct {
     Profile *PrefetchProfile
 }
 
+func NewFileInformationVista(reader io.ReaderAt) *FileInformationVista {
+    self := &FileInformationVista{Reader: reader}
+    return self
+}
+
 func (self *FileInformationVista) Size() int {
     return 156
 }
 
 func (self *FileInformationVista) FileMetricsOffset() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_FileMetricsOffset + self.Offset)
-}
-
-func (self *FileInformationVista) NumberOfFileMetrics() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_NumberOfFileMetrics + self.Offset)
-}
-
-func (self *FileInformationVista) TraceChainsArrayOffset() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_TraceChainsArrayOffset + self.Offset)
-}
-
-func (self *FileInformationVista) NumberOfTraceChains() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_NumberOfTraceChains + self.Offset)
 }
 
 func (self *FileInformationVista) FilenameOffset() uint32 {
@@ -155,38 +135,50 @@ func (self *FileInformationVista) FilenameSize() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_FilenameSize + self.Offset)
 }
 
-func (self *FileInformationVista) VolumesInformationOffset() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_VolumesInformationOffset + self.Offset)
+func (self *FileInformationVista) LastRunTime() *WinFileTime {
+    return self.Profile.WinFileTime(self.Reader, self.Profile.Off_FileInformationVista_LastRunTime + self.Offset)
+}
+
+func (self *FileInformationVista) NumberOfFileMetrics() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_NumberOfFileMetrics + self.Offset)
+}
+
+func (self *FileInformationVista) NumberOfTraceChains() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_NumberOfTraceChains + self.Offset)
 }
 
 func (self *FileInformationVista) NumberOfVolumes() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_NumberOfVolumes + self.Offset)
 }
 
-func (self *FileInformationVista) VolumesInformationSize() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_VolumesInformationSize + self.Offset)
-}
-
-func (self *FileInformationVista) LastRunTime() *WinFileTime {
-    return self.Profile.WinFileTime(self.Reader, self.Profile.Off_FileInformationVista_LastRunTime + self.Offset)
-}
-
 func (self *FileInformationVista) RunCount() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_RunCount + self.Offset)
 }
+
+func (self *FileInformationVista) TraceChainsArrayOffset() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_TraceChainsArrayOffset + self.Offset)
+}
+
+func (self *FileInformationVista) VolumesInformationOffset() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_VolumesInformationOffset + self.Offset)
+}
+
+func (self *FileInformationVista) VolumesInformationSize() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationVista_VolumesInformationSize + self.Offset)
+}
 func (self *FileInformationVista) DebugString() string {
     result := fmt.Sprintf("struct FileInformationVista @ %#x:\n", self.Offset)
-    result += fmt.Sprintf("  FileMetricsOffset: %#0x\n", self.FileMetricsOffset())
-    result += fmt.Sprintf("  NumberOfFileMetrics: %#0x\n", self.NumberOfFileMetrics())
-    result += fmt.Sprintf("  TraceChainsArrayOffset: %#0x\n", self.TraceChainsArrayOffset())
-    result += fmt.Sprintf("  NumberOfTraceChains: %#0x\n", self.NumberOfTraceChains())
-    result += fmt.Sprintf("  FilenameOffset: %#0x\n", self.FilenameOffset())
-    result += fmt.Sprintf("  FilenameSize: %#0x\n", self.FilenameSize())
-    result += fmt.Sprintf("  VolumesInformationOffset: %#0x\n", self.VolumesInformationOffset())
-    result += fmt.Sprintf("  NumberOfVolumes: %#0x\n", self.NumberOfVolumes())
-    result += fmt.Sprintf("  VolumesInformationSize: %#0x\n", self.VolumesInformationSize())
-    result += fmt.Sprintf("  LastRunTime: {\n%v}\n", indent(self.LastRunTime().DebugString()))
-    result += fmt.Sprintf("  RunCount: %#0x\n", self.RunCount())
+    result += fmt.Sprintf("FileMetricsOffset: %#0x\n", self.FileMetricsOffset())
+    result += fmt.Sprintf("FilenameOffset: %#0x\n", self.FilenameOffset())
+    result += fmt.Sprintf("FilenameSize: %#0x\n", self.FilenameSize())
+    result += fmt.Sprintf("LastRunTime: {\n%v}\n", self.LastRunTime().DebugString())
+    result += fmt.Sprintf("NumberOfFileMetrics: %#0x\n", self.NumberOfFileMetrics())
+    result += fmt.Sprintf("NumberOfTraceChains: %#0x\n", self.NumberOfTraceChains())
+    result += fmt.Sprintf("NumberOfVolumes: %#0x\n", self.NumberOfVolumes())
+    result += fmt.Sprintf("RunCount: %#0x\n", self.RunCount())
+    result += fmt.Sprintf("TraceChainsArrayOffset: %#0x\n", self.TraceChainsArrayOffset())
+    result += fmt.Sprintf("VolumesInformationOffset: %#0x\n", self.VolumesInformationOffset())
+    result += fmt.Sprintf("VolumesInformationSize: %#0x\n", self.VolumesInformationSize())
     return result
 }
 
@@ -196,24 +188,25 @@ type FileInformationWin10 struct {
     Profile *PrefetchProfile
 }
 
+func NewFileInformationWin10(reader io.ReaderAt) *FileInformationWin10 {
+    self := &FileInformationWin10{Reader: reader}
+    return self
+}
+
 func (self *FileInformationWin10) Size() int {
     return 224
 }
 
+func (self *FileInformationWin10) ExecutablePathOffset() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_ExecutablePathOffset + self.Offset)
+}
+
+func (self *FileInformationWin10) ExecutablePathSize() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_ExecutablePathSize + self.Offset)
+}
+
 func (self *FileInformationWin10) FileMetricsOffset() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_FileMetricsOffset + self.Offset)
-}
-
-func (self *FileInformationWin10) NumberOfFileMetrics() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_NumberOfFileMetrics + self.Offset)
-}
-
-func (self *FileInformationWin10) TraceChainsArrayOffset() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_TraceChainsArrayOffset + self.Offset)
-}
-
-func (self *FileInformationWin10) NumberOfTraceChains() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_NumberOfTraceChains + self.Offset)
 }
 
 func (self *FileInformationWin10) FilenameOffset() uint32 {
@@ -224,20 +217,20 @@ func (self *FileInformationWin10) FilenameSize() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_FilenameSize + self.Offset)
 }
 
-func (self *FileInformationWin10) VolumesInformationOffset() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_VolumesInformationOffset + self.Offset)
+func (self *FileInformationWin10) LastRunTimes() []*WinFileTime {
+   return ParseArray_WinFileTime(self.Profile, self.Reader, self.Profile.Off_FileInformationWin10_LastRunTimes + self.Offset, 8)
+}
+
+func (self *FileInformationWin10) NumberOfFileMetrics() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_NumberOfFileMetrics + self.Offset)
+}
+
+func (self *FileInformationWin10) NumberOfTraceChains() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_NumberOfTraceChains + self.Offset)
 }
 
 func (self *FileInformationWin10) NumberOfVolumes() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_NumberOfVolumes + self.Offset)
-}
-
-func (self *FileInformationWin10) VolumesInformationSize() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_VolumesInformationSize + self.Offset)
-}
-
-func (self *FileInformationWin10) LastRunTimes() []*WinFileTime {
-   return ParseArray_WinFileTime(self.Profile, self.Reader, self.Profile.Off_FileInformationWin10_LastRunTimes + self.Offset, 8)
 }
 
 func (self *FileInformationWin10) RunCount1() uint32 {
@@ -247,19 +240,33 @@ func (self *FileInformationWin10) RunCount1() uint32 {
 func (self *FileInformationWin10) RunCount2() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_RunCount2 + self.Offset)
 }
+
+func (self *FileInformationWin10) TraceChainsArrayOffset() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_TraceChainsArrayOffset + self.Offset)
+}
+
+func (self *FileInformationWin10) VolumesInformationOffset() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_VolumesInformationOffset + self.Offset)
+}
+
+func (self *FileInformationWin10) VolumesInformationSize() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationWin10_VolumesInformationSize + self.Offset)
+}
 func (self *FileInformationWin10) DebugString() string {
     result := fmt.Sprintf("struct FileInformationWin10 @ %#x:\n", self.Offset)
-    result += fmt.Sprintf("  FileMetricsOffset: %#0x\n", self.FileMetricsOffset())
-    result += fmt.Sprintf("  NumberOfFileMetrics: %#0x\n", self.NumberOfFileMetrics())
-    result += fmt.Sprintf("  TraceChainsArrayOffset: %#0x\n", self.TraceChainsArrayOffset())
-    result += fmt.Sprintf("  NumberOfTraceChains: %#0x\n", self.NumberOfTraceChains())
-    result += fmt.Sprintf("  FilenameOffset: %#0x\n", self.FilenameOffset())
-    result += fmt.Sprintf("  FilenameSize: %#0x\n", self.FilenameSize())
-    result += fmt.Sprintf("  VolumesInformationOffset: %#0x\n", self.VolumesInformationOffset())
-    result += fmt.Sprintf("  NumberOfVolumes: %#0x\n", self.NumberOfVolumes())
-    result += fmt.Sprintf("  VolumesInformationSize: %#0x\n", self.VolumesInformationSize())
-    result += fmt.Sprintf("  RunCount1: %#0x\n", self.RunCount1())
-    result += fmt.Sprintf("  RunCount2: %#0x\n", self.RunCount2())
+    result += fmt.Sprintf("ExecutablePathOffset: %#0x\n", self.ExecutablePathOffset())
+    result += fmt.Sprintf("ExecutablePathSize: %#0x\n", self.ExecutablePathSize())
+    result += fmt.Sprintf("FileMetricsOffset: %#0x\n", self.FileMetricsOffset())
+    result += fmt.Sprintf("FilenameOffset: %#0x\n", self.FilenameOffset())
+    result += fmt.Sprintf("FilenameSize: %#0x\n", self.FilenameSize())
+    result += fmt.Sprintf("NumberOfFileMetrics: %#0x\n", self.NumberOfFileMetrics())
+    result += fmt.Sprintf("NumberOfTraceChains: %#0x\n", self.NumberOfTraceChains())
+    result += fmt.Sprintf("NumberOfVolumes: %#0x\n", self.NumberOfVolumes())
+    result += fmt.Sprintf("RunCount1: %#0x\n", self.RunCount1())
+    result += fmt.Sprintf("RunCount2: %#0x\n", self.RunCount2())
+    result += fmt.Sprintf("TraceChainsArrayOffset: %#0x\n", self.TraceChainsArrayOffset())
+    result += fmt.Sprintf("VolumesInformationOffset: %#0x\n", self.VolumesInformationOffset())
+    result += fmt.Sprintf("VolumesInformationSize: %#0x\n", self.VolumesInformationSize())
     return result
 }
 
@@ -267,6 +274,11 @@ type FileInformationXP struct {
     Reader io.ReaderAt
     Offset int64
     Profile *PrefetchProfile
+}
+
+func NewFileInformationXP(reader io.ReaderAt) *FileInformationXP {
+    self := &FileInformationXP{Reader: reader}
+    return self
 }
 
 func (self *FileInformationXP) Size() int {
@@ -277,18 +289,6 @@ func (self *FileInformationXP) FileMetricsOffset() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_FileMetricsOffset + self.Offset)
 }
 
-func (self *FileInformationXP) NumberOfFileMetrics() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_NumberOfFileMetrics + self.Offset)
-}
-
-func (self *FileInformationXP) TraceChainsArrayOffset() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_TraceChainsArrayOffset + self.Offset)
-}
-
-func (self *FileInformationXP) NumberOfTraceChains() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_NumberOfTraceChains + self.Offset)
-}
-
 func (self *FileInformationXP) FilenameOffset() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_FilenameOffset + self.Offset)
 }
@@ -297,38 +297,50 @@ func (self *FileInformationXP) FilenameSize() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_FilenameSize + self.Offset)
 }
 
-func (self *FileInformationXP) VolumesInformationOffset() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_VolumesInformationOffset + self.Offset)
+func (self *FileInformationXP) LastRunTime() *WinFileTime {
+    return self.Profile.WinFileTime(self.Reader, self.Profile.Off_FileInformationXP_LastRunTime + self.Offset)
+}
+
+func (self *FileInformationXP) NumberOfFileMetrics() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_NumberOfFileMetrics + self.Offset)
+}
+
+func (self *FileInformationXP) NumberOfTraceChains() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_NumberOfTraceChains + self.Offset)
 }
 
 func (self *FileInformationXP) NumberOfVolumes() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_NumberOfVolumes + self.Offset)
 }
 
-func (self *FileInformationXP) VolumesInformationSize() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_VolumesInformationSize + self.Offset)
-}
-
-func (self *FileInformationXP) LastRunTime() *WinFileTime {
-    return self.Profile.WinFileTime(self.Reader, self.Profile.Off_FileInformationXP_LastRunTime + self.Offset)
-}
-
 func (self *FileInformationXP) RunCount() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_RunCount + self.Offset)
 }
+
+func (self *FileInformationXP) TraceChainsArrayOffset() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_TraceChainsArrayOffset + self.Offset)
+}
+
+func (self *FileInformationXP) VolumesInformationOffset() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_VolumesInformationOffset + self.Offset)
+}
+
+func (self *FileInformationXP) VolumesInformationSize() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileInformationXP_VolumesInformationSize + self.Offset)
+}
 func (self *FileInformationXP) DebugString() string {
     result := fmt.Sprintf("struct FileInformationXP @ %#x:\n", self.Offset)
-    result += fmt.Sprintf("  FileMetricsOffset: %#0x\n", self.FileMetricsOffset())
-    result += fmt.Sprintf("  NumberOfFileMetrics: %#0x\n", self.NumberOfFileMetrics())
-    result += fmt.Sprintf("  TraceChainsArrayOffset: %#0x\n", self.TraceChainsArrayOffset())
-    result += fmt.Sprintf("  NumberOfTraceChains: %#0x\n", self.NumberOfTraceChains())
-    result += fmt.Sprintf("  FilenameOffset: %#0x\n", self.FilenameOffset())
-    result += fmt.Sprintf("  FilenameSize: %#0x\n", self.FilenameSize())
-    result += fmt.Sprintf("  VolumesInformationOffset: %#0x\n", self.VolumesInformationOffset())
-    result += fmt.Sprintf("  NumberOfVolumes: %#0x\n", self.NumberOfVolumes())
-    result += fmt.Sprintf("  VolumesInformationSize: %#0x\n", self.VolumesInformationSize())
-    result += fmt.Sprintf("  LastRunTime: {\n%v}\n", indent(self.LastRunTime().DebugString()))
-    result += fmt.Sprintf("  RunCount: %#0x\n", self.RunCount())
+    result += fmt.Sprintf("FileMetricsOffset: %#0x\n", self.FileMetricsOffset())
+    result += fmt.Sprintf("FilenameOffset: %#0x\n", self.FilenameOffset())
+    result += fmt.Sprintf("FilenameSize: %#0x\n", self.FilenameSize())
+    result += fmt.Sprintf("LastRunTime: {\n%v}\n", self.LastRunTime().DebugString())
+    result += fmt.Sprintf("NumberOfFileMetrics: %#0x\n", self.NumberOfFileMetrics())
+    result += fmt.Sprintf("NumberOfTraceChains: %#0x\n", self.NumberOfTraceChains())
+    result += fmt.Sprintf("NumberOfVolumes: %#0x\n", self.NumberOfVolumes())
+    result += fmt.Sprintf("RunCount: %#0x\n", self.RunCount())
+    result += fmt.Sprintf("TraceChainsArrayOffset: %#0x\n", self.TraceChainsArrayOffset())
+    result += fmt.Sprintf("VolumesInformationOffset: %#0x\n", self.VolumesInformationOffset())
+    result += fmt.Sprintf("VolumesInformationSize: %#0x\n", self.VolumesInformationSize())
     return result
 }
 
@@ -338,21 +350,26 @@ type FileMetricsEntryV17 struct {
     Profile *PrefetchProfile
 }
 
-func (self *FileMetricsEntryV17) Size() int {
-    return 20
+func NewFileMetricsEntryV17(reader io.ReaderAt) *FileMetricsEntryV17 {
+    self := &FileMetricsEntryV17{Reader: reader}
+    return self
 }
 
-func (self *FileMetricsEntryV17) FilenameOffset() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileMetricsEntryV17_FilenameOffset + self.Offset)
+func (self *FileMetricsEntryV17) Size() int {
+    return 20
 }
 
 func (self *FileMetricsEntryV17) FilenameLength() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileMetricsEntryV17_FilenameLength + self.Offset)
 }
+
+func (self *FileMetricsEntryV17) FilenameOffset() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileMetricsEntryV17_FilenameOffset + self.Offset)
+}
 func (self *FileMetricsEntryV17) DebugString() string {
     result := fmt.Sprintf("struct FileMetricsEntryV17 @ %#x:\n", self.Offset)
-    result += fmt.Sprintf("  FilenameOffset: %#0x\n", self.FilenameOffset())
-    result += fmt.Sprintf("  FilenameLength: %#0x\n", self.FilenameLength())
+    result += fmt.Sprintf("FilenameLength: %#0x\n", self.FilenameLength())
+    result += fmt.Sprintf("FilenameOffset: %#0x\n", self.FilenameOffset())
     return result
 }
 
@@ -362,16 +379,21 @@ type FileMetricsEntryV30 struct {
     Profile *PrefetchProfile
 }
 
+func NewFileMetricsEntryV30(reader io.ReaderAt) *FileMetricsEntryV30 {
+    self := &FileMetricsEntryV30{Reader: reader}
+    return self
+}
+
 func (self *FileMetricsEntryV30) Size() int {
     return 32
 }
 
-func (self *FileMetricsEntryV30) FilenameOffset() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_FileMetricsEntryV30_FilenameOffset + self.Offset)
-}
-
 func (self *FileMetricsEntryV30) FilenameLength() uint32 {
    return ParseUint32(self.Reader, self.Profile.Off_FileMetricsEntryV30_FilenameLength + self.Offset)
+}
+
+func (self *FileMetricsEntryV30) FilenameOffset() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_FileMetricsEntryV30_FilenameOffset + self.Offset)
 }
 
 func (self *FileMetricsEntryV30) MFTFileReference() uint64 {
@@ -379,9 +401,9 @@ func (self *FileMetricsEntryV30) MFTFileReference() uint64 {
 }
 func (self *FileMetricsEntryV30) DebugString() string {
     result := fmt.Sprintf("struct FileMetricsEntryV30 @ %#x:\n", self.Offset)
-    result += fmt.Sprintf("  FilenameOffset: %#0x\n", self.FilenameOffset())
-    result += fmt.Sprintf("  FilenameLength: %#0x\n", self.FilenameLength())
-    result += fmt.Sprintf("  MFTFileReference: %#0x\n", self.MFTFileReference())
+    result += fmt.Sprintf("FilenameLength: %#0x\n", self.FilenameLength())
+    result += fmt.Sprintf("FilenameOffset: %#0x\n", self.FilenameOffset())
+    result += fmt.Sprintf("MFTFileReference: %#0x\n", self.MFTFileReference())
     return result
 }
 
@@ -389,6 +411,11 @@ type MAMHeader struct {
     Reader io.ReaderAt
     Offset int64
     Profile *PrefetchProfile
+}
+
+func NewMAMHeader(reader io.ReaderAt) *MAMHeader {
+    self := &MAMHeader{Reader: reader}
+    return self
 }
 
 func (self *MAMHeader) Size() int {
@@ -405,8 +432,8 @@ func (self *MAMHeader) UncompressedSize() uint32 {
 }
 func (self *MAMHeader) DebugString() string {
     result := fmt.Sprintf("struct MAMHeader @ %#x:\n", self.Offset)
-    result += fmt.Sprintf("  Signature: %v\n", string(self.Signature()))
-    result += fmt.Sprintf("  UncompressedSize: %#0x\n", self.UncompressedSize())
+    result += fmt.Sprintf("Signature: %v\n", string(self.Signature()))
+    result += fmt.Sprintf("UncompressedSize: %#0x\n", self.UncompressedSize())
     return result
 }
 
@@ -416,8 +443,31 @@ type SCCAHeader struct {
     Profile *PrefetchProfile
 }
 
+func NewSCCAHeader(reader io.ReaderAt) *SCCAHeader {
+    self := &SCCAHeader{Reader: reader}
+    return self
+}
+
 func (self *SCCAHeader) Size() int {
     return 84
+}
+
+
+func (self *SCCAHeader) Executable() string {
+  return ParseTerminatedUTF16String(self.Reader, self.Profile.Off_SCCAHeader_Executable + self.Offset)
+}
+
+func (self *SCCAHeader) FileSize() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_SCCAHeader_FileSize + self.Offset)
+}
+
+func (self *SCCAHeader) Hash() uint32 {
+   return ParseUint32(self.Reader, self.Profile.Off_SCCAHeader_Hash + self.Offset)
+}
+
+
+func (self *SCCAHeader) Signature() string {
+  return ParseString(self.Reader, self.Profile.Off_SCCAHeader_Signature + self.Offset, 4)
 }
 
 func (self *SCCAHeader) Version() *Enumeration {
@@ -443,31 +493,13 @@ func (self *SCCAHeader) Version() *Enumeration {
    return &Enumeration{Value: uint64(value), Name: name}
 }
 
-
-
-func (self *SCCAHeader) Signature() string {
-  return ParseString(self.Reader, self.Profile.Off_SCCAHeader_Signature + self.Offset, 4)
-}
-
-func (self *SCCAHeader) FileSize() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_SCCAHeader_FileSize + self.Offset)
-}
-
-
-func (self *SCCAHeader) Executable() string {
-  return ParseTerminatedUTF16String(self.Reader, self.Profile.Off_SCCAHeader_Executable + self.Offset)
-}
-
-func (self *SCCAHeader) Hash() uint32 {
-   return ParseUint32(self.Reader, self.Profile.Off_SCCAHeader_Hash + self.Offset)
-}
 func (self *SCCAHeader) DebugString() string {
     result := fmt.Sprintf("struct SCCAHeader @ %#x:\n", self.Offset)
-    result += fmt.Sprintf("  Version: %v\n", self.Version().DebugString())
-    result += fmt.Sprintf("  Signature: %v\n", string(self.Signature()))
-    result += fmt.Sprintf("  FileSize: %#0x\n", self.FileSize())
-    result += fmt.Sprintf("  Executable: %v\n", string(self.Executable()))
-    result += fmt.Sprintf("  Hash: %#0x\n", self.Hash())
+    result += fmt.Sprintf("Executable: %v\n", string(self.Executable()))
+    result += fmt.Sprintf("FileSize: %#0x\n", self.FileSize())
+    result += fmt.Sprintf("Hash: %#0x\n", self.Hash())
+    result += fmt.Sprintf("Signature: %v\n", string(self.Signature()))
+    result += fmt.Sprintf("Version: %v\n", self.Version().DebugString())
     return result
 }
 
@@ -482,7 +514,7 @@ func (self Enumeration) DebugString() string {
 
 
 func ParseArray_WinFileTime(profile *PrefetchProfile, reader io.ReaderAt, offset int64, count int) []*WinFileTime {
-    result := make([]*WinFileTime, 0, count)
+    result := []*WinFileTime{}
     for i:=0; i<count; i++ {
       value := profile.WinFileTime(reader, offset)
       result = append(result, value)
@@ -492,8 +524,7 @@ func ParseArray_WinFileTime(profile *PrefetchProfile, reader io.ReaderAt, offset
 }
 
 func ParseUint32(reader io.ReaderAt, offset int64) uint32 {
-	var buf [4]byte
-	data := buf[:]
+    data := make([]byte, 4)
     _, err := reader.ReadAt(data, offset)
     if err != nil {
        return 0
@@ -502,8 +533,7 @@ func ParseUint32(reader io.ReaderAt, offset int64) uint32 {
 }
 
 func ParseUint64(reader io.ReaderAt, offset int64) uint64 {
-	var buf [8]byte
-	data := buf[:]
+    data := make([]byte, 8)
     _, err := reader.ReadAt(data, offset)
     if err != nil {
        return 0
@@ -512,8 +542,7 @@ func ParseUint64(reader io.ReaderAt, offset int64) uint64 {
 }
 
 func ParseTerminatedString(reader io.ReaderAt, offset int64) string {
-   var buf [1024]byte
-   data := buf[:]
+   data := make([]byte, 1024)
    n, err := reader.ReadAt(data, offset)
    if err != nil && err != io.EOF {
      return ""
@@ -536,8 +565,7 @@ func ParseString(reader io.ReaderAt, offset int64, length int64) string {
 
 
 func ParseTerminatedUTF16String(reader io.ReaderAt, offset int64) string {
-   var buf [1024]byte
-   data := buf[:]
+   data := make([]byte, 1024)
    n, err := reader.ReadAt(data, offset)
    if err != nil && err != io.EOF {
      return ""
@@ -547,10 +575,7 @@ func ParseTerminatedUTF16String(reader io.ReaderAt, offset int64) string {
    if idx < 0 {
       idx = n-1
    }
-   if idx%2 != 0 {
-      idx += 1
-   }
-   return UTF16BytesToUTF8(data[0:idx], binary.LittleEndian)
+   return UTF16BytesToUTF8(data[0:idx+1], binary.LittleEndian)
 }
 
 func ParseUTF16String(reader io.ReaderAt, offset int64, length int64) string {

--- a/profile_vtypes.json
+++ b/profile_vtypes.json
@@ -37,7 +37,9 @@
     }]],
 
     "RunCount1": [124, ["unsigned long"]],
-    "RunCount2": [116, ["unsigned long"]]
+    "RunCount2": [116, ["unsigned long"]],
+    "ExecutablePathOffset": [128, ["unsigned long"]],
+    "ExecutablePathSize": [132, ["unsigned long"]]
   }],
 
   "FileMetricsEntryV30": [32, {


### PR DESCRIPTION
Windows 10 prefetch files (I haven't tested on older versions) contain a field that contains a kernel path to the executable (e.g. `\DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\CMD.EXE`).

Since this is more precise than the executable basename contained in the header, this is interesting for forensics; the location can be quite meaningful for e.g. LOLBAS.

Admittedly, I only found this via manually looking at the decompressed data; I don't have a reference where this is documented or where another parser processes this (PECmd doesn't parse it).